### PR TITLE
Fix full-screen logo hiding on notched displays (detect via Spaces API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ xcuserdata/
 
 ## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
 build/
+build-release/
 DerivedData/
 *.moved-aside
 *.pbxuser

--- a/Logoer/LogoerApp.swift
+++ b/Logoer/LogoerApp.swift
@@ -172,20 +172,50 @@ func createLogo(noCache: Bool = false) {
     }
 }
 
+// Private CoreGraphics "Spaces" API. We ask the window server which displays are
+// currently showing a native full-screen Space. This is the only reliable signal:
+// on notched Macs a full-screen window's bounds are identical to a merely *maximized*
+// window's (both render below the notch), so comparing window rectangles can never
+// tell full screen from maximized. Asking about the Space type sidesteps that entirely,
+// works for any app, and is per-display.
+typealias CGSConnectionID = UInt32
+@_silgen_name("_CGSDefaultConnection")
+func _CGSDefaultConnection() -> CGSConnectionID
+@_silgen_name("CGSCopyManagedDisplaySpaces")
+func CGSCopyManagedDisplaySpaces(_ cid: CGSConnectionID) -> Unmanaged<CFArray>
+
+// CGS reports a native full-screen Space with type == 4.
+private let kCGSSpaceTypeFullscreen = 4
+
+// Stable UUID string for a screen, used to match an NSScreen to a CGS managed display.
+func screenUUID(_ screen: NSScreen) -> String? {
+    guard let num = screen.deviceDescription[NSDeviceDescriptionKey(rawValue: "NSScreenNumber")] as? NSNumber,
+          let cf = CGDisplayCreateUUIDFromDisplayID(CGDirectDisplayID(num.uint32Value))?.takeRetainedValue()
+    else { return nil }
+    return CFUUIDCreateString(nil, cf) as String
+}
+
 func getFullScreens() {
-    var screenList = [NSRect]()
-    if let windows = CGWindowListCopyWindowInfo([.excludeDesktopElements, .optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] {
-        for window in windows {
-            if getOwner(window) == "SystemUIServer" { continue }
-            if let level = window[kCGWindowLayer as String] as? Int { if level != 0 { continue } }
-            if let bounds = window[kCGWindowBounds as String] as? [String: CGFloat] {
-                let windowRect = CGRect(x: bounds["X"] ?? 0, y: bounds["Y"] ?? 0, width: bounds["Width"] ?? 0, height: bounds["Height"] ?? 0)
-                for screen in NSScreen.screens {
-                    if windowRect.equalTo(screen.frame) { screenList.append(screen.frame) }
-                }
-            }
+    // Which displays currently show a native full-screen Space?
+    var fullScreenDisplayIDs = Set<String>()
+    if let displays = CGSCopyManagedDisplaySpaces(_CGSDefaultConnection()).takeRetainedValue() as? [[String: Any]] {
+        for display in displays {
+            guard let id = display["Display Identifier"] as? String,
+                  let current = display["Current Space"] as? [String: Any],
+                  let type = current["type"] as? Int else { continue }
+            if type == kCGSSpaceTypeFullscreen { fullScreenDisplayIDs.insert(id) }
         }
     }
+
+    // Map those displays back to NSScreen frames (the unit ContentView compares against).
+    // "Main" is accepted as a fallback identifier for the primary display on some macOS versions.
+    var screenList = [NSRect]()
+    for screen in NSScreen.screens {
+        let matchesUUID = screenUUID(screen).map { fullScreenDisplayIDs.contains($0) } ?? false
+        let matchesMain = fullScreenDisplayIDs.contains("Main") && screen.isMainScreen
+        if matchesUUID || matchesMain { screenList.append(screen.frame) }
+    }
+
     if screenList != dataModel.fullScreens {
         if screenList.count < dataModel.fullScreens.count {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -195,19 +225,6 @@ func getFullScreens() {
         }
         dataModel.fullScreens = screenList
     }
-}
-
-func getOwner(_ w: [String: Any]) -> String {
-    let name = w["kCGWindowOwnerName"] as? String ?? ""
-    if name.contains("pid=") {
-        guard let pid = w["kCGWindowOwnerPID"] as? Int else { return "" }
-        for app in NSWorkspace.shared.runningApplications {
-            if let name = app.localizedName, app.processIdentifier == pid {
-                return name
-            }
-        }
-    }
-    return name
 }
 
 func getOrigin(of screen: NSScreen, in screens: [NSScreen]) -> NSPoint {


### PR DESCRIPTION
## Summary

On notched MacBooks (Sequoia/Tahoe) the logo did not hide when an app entered native full screen, and once hidden it could stay stuck until the app was relaunched. This fixes both, for any app, on any display.

## Root cause

The old `getFullScreens()` recognised full screen by matching window bounds against the screen frame (`windowRect.equalTo(screen.frame)`). On notched displays that can never be made to work, because a native full-screen window and a merely **maximized** (green-zoom) window report **identical** bounds, both rendering below the notch.

Verified live on macOS 26 with a built-in notched display:

| window | reported bounds |
| --- | --- |
| maximized Chrome (menu bar visible) | `(0, 34, 1710, 1073)` |
| **full-screen** Chrome | `(0, 34, 1710, 1073)` |

There is also no persistent full-screen-sized window to key off (only a 1-frame flicker during the transition). So any geometry-based rule must pick one horn of a dilemma: either miss full screen (logo never hides) or fire on maximized windows (logo hides when it shouldn't, and gets "stuck" because a maximized window is usually present after exiting).

## Fix

Ask the window server directly instead of guessing from rectangles. The CoreGraphics Spaces API (`CGSCopyManagedDisplaySpaces`) reports each display's current Space type; a native full-screen Space is `type == 4`. We collect the displays currently in a full-screen Space and map them back to `NSScreen` frames by display UUID.

This is:
- **app-agnostic** (works for any app, not specific window shapes),
- **per-display** (correct on multi-monitor setups), and
- **immediate on exit** (the Space type flips back to normal the instant full screen ends, so the logo reappears with no stuck state).

Verified across repeated enter/exit cycles on the built-in notched display: `FULLSCREEN -> normal -> FULLSCREEN -> normal`, logo hides/reappears correctly each time, and stays visible for maximized windows.

Also removes the now-dead `isFullScreenWindow()` and `getOwner()` helpers.

## Notes

- This uses a private CoreGraphics API. That is consistent with the existing use of the private `CGWindowList` API in this file, and Logoer ships outside the App Store. If `CGSCopyManagedDisplaySpaces` ever returns nothing on a future OS, the code degrades gracefully (logo simply stays visible).
- Apps using **non-native** full screen (e.g. iTerm2's "non-native full screen windows" option) do not create a full-screen Space and are intentionally not matched, since such windows are geometrically indistinguishable from a maximized window.

Closes #29
Closes #30
